### PR TITLE
Fixed bug causing a double escaping of the query when doing an advanced search in the browser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module linguee
+
+go 1.16
+
+require (
+	github.com/PuerkitoBio/goquery v1.7.1
+	github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da
+	github.com/pascalw/go-alfred v0.0.0-20160913054623-16aeb807166c
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/PuerkitoBio/goquery v1.7.1 h1:oE+T06D+1T7LNrn91B4aERsRIeCLJ/oPSa6xB9FPnz4=
+github.com/PuerkitoBio/goquery v1.7.1/go.mod h1:XY0pP4kfraEmmV1O7Uf6XyjoslwsneBbgeDjLYuN8xY=
+github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
+github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
+github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da h1:0qwwqQCLOOXPl58ljnq3sTJR7yRuMolM02vjxDh4ZVE=
+github.com/djimenez/iconv-go v0.0.0-20160305225143-8960e66bd3da/go.mod h1:ns+zIWBBchgfRdxNgIJWn2x6U95LQchxeqiN5Cgdgts=
+github.com/pascalw/go-alfred v0.0.0-20160913054623-16aeb807166c h1:j6+n6AEmqTs6XyfTKVaq4Bzc4vCnjwF0BbchwR7UP+U=
+github.com/pascalw/go-alfred v0.0.0-20160913054623-16aeb807166c/go.mod h1:O821yF1VSi86tviHFEO4FN4TUjVt46UUqT6XGEaMYhk=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/linguee.go
+++ b/linguee.go
@@ -61,7 +61,7 @@ func main() {
 			Valid: true,
 			Uid:   "origin",
 			Title: origin,
-			Arg:   fmt.Sprintf("http://www.linguee.com/%s/search?source=auto&query=%s", args.Lang, url.QueryEscape(args.Query)),
+			Arg:   fmt.Sprintf("http://www.linguee.com/%s/search?source=auto&query=%s", args.Lang, args.Query),
 		})
 	}
 


### PR DESCRIPTION
I noticed that advanced searches in the browser failed when using umlauts and realised this is because the query is escaped twice in the process which for example causes the string `darüber hinaus` to be escaped correctly (`ü -> %C3%BC`) to `dar%C3%BCber+hinaus` and then another time (`% -> %25`) to `dar%25C3%25BCber+hinaus`.

It should be fixed here.

Unfortunately I didn't know how to build the `.alfredworkflow` package myself so I would leave this to you @alexander-heimbuch ...

PS: Thanks for the excellent workflow! I use it a lot on a daily basis since more than a year!